### PR TITLE
fix can not draw the navigation mesh in Unity 5

### DIFF
--- a/src/main/Assets/CAI/util-u3d/DebugDraw.cs
+++ b/src/main/Assets/CAI/util-u3d/DebugDraw.cs
@@ -92,13 +92,9 @@ namespace org.critterai.u3d
             {
                 if (!mSimpleMaterial)
                 {
-                    mSimpleMaterial = new Material(
-                        "Shader \"Lines/Colored Blended\" {"
-                        + "SubShader { Pass { "
-                        + "	BindChannels { Bind \"Color\",color } "
-                        + "	Blend SrcAlpha OneMinusSrcAlpha "
-                        + "	ZWrite Off Cull Off Fog { Mode Off } "
-                        + "} } }");
+                    /// using Hidden/Internal-Colored to replace
+		            var drawLine = Shader.Find("Hidden/Internal-Colored");
+		            mSimpleMaterial = new Material(drawLine);
                     mSimpleMaterial.hideFlags = HideFlags.HideAndDontSave;
                     mSimpleMaterial.shader.hideFlags = HideFlags.HideAndDontSave;
                 }


### PR DESCRIPTION
using Hidden/Internal-Colored to replace Lines/Colored Blended to fix CritterAI can not draw the navigation mesh in Unity 5
